### PR TITLE
Reducing memory usage

### DIFF
--- a/wrapper.go
+++ b/wrapper.go
@@ -6,9 +6,10 @@ import (
 )
 
 type writer struct {
-	Sep string
 	Len int
+	Sep string
 
+	sepBytes []byte
 	w io.Writer
 	i int
 }
@@ -25,7 +26,7 @@ func (w *writer) Write(b []byte) (N int, err error) {
 		N += n
 		b = b[to:]
 
-		_, err = w.w.Write([]byte(w.Sep))
+		_, err = w.w.Write(w.sepBytes)
 		if err != nil {
 			return
 		}
@@ -49,8 +50,9 @@ func (w *writer) Write(b []byte) (N int, err error) {
 // length and adds a separator between these parts.
 func New(w io.Writer, sep string, l int) io.Writer {
 	return &writer{
-		Sep: sep,
 		Len: l,
+		Sep: sep,
+		sepBytes: []byte(sep),
 		w: w,
 	}
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -6,12 +6,12 @@ import (
 )
 
 type writer struct {
-	Len int
 	Sep string
+	Len int
 
 	sepBytes []byte
-	w io.Writer
-	i int
+	w        io.Writer
+	i        int
 }
 
 func (w *writer) Write(b []byte) (N int, err error) {
@@ -50,10 +50,10 @@ func (w *writer) Write(b []byte) (N int, err error) {
 // length and adds a separator between these parts.
 func New(w io.Writer, sep string, l int) io.Writer {
 	return &writer{
-		Len: l,
-		Sep: sep,
+		Len:      l,
+		Sep:      sep,
 		sepBytes: []byte(sep),
-		w: w,
+		w:        w,
 	}
 }
 

--- a/wrapper.go
+++ b/wrapper.go
@@ -6,7 +6,6 @@ import (
 )
 
 type writer struct {
-	Sep string
 	Len int
 
 	sepBytes []byte
@@ -51,7 +50,6 @@ func (w *writer) Write(b []byte) (N int, err error) {
 func New(w io.Writer, sep string, l int) io.Writer {
 	return &writer{
 		Len:      l,
-		Sep:      sep,
 		sepBytes: []byte(sep),
 		w:        w,
 	}

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -2,38 +2,39 @@ package textwrapper_test
 
 import (
 	"bytes"
+	"io/ioutil"
 	"testing"
 
 	"github.com/emersion/go-textwrapper"
 )
 
 func TestNew(t *testing.T) {
-	tests := []struct{
-		input []string
+	tests := []struct {
+		input    []string
 		expected string
 	}{
 		{
-			input: []string{"helloworldhelloworldhelloworld"},
+			input:    []string{"helloworldhelloworldhelloworld"},
 			expected: "hello/world/hello/world/hello/world",
 		},
 		{
-			input: []string{"helloworldhelloworldhe"},
+			input:    []string{"helloworldhelloworldhe"},
 			expected: "hello/world/hello/world/he",
 		},
 		{
-			input: []string{"helloworldhelloworldhe", "ll"},
+			input:    []string{"helloworldhelloworldhe", "ll"},
 			expected: "hello/world/hello/world/hell",
 		},
 		{
-			input: []string{"helloworldhelloworldhe", "llo"},
+			input:    []string{"helloworldhelloworldhe", "llo"},
 			expected: "hello/world/hello/world/hello",
 		},
 		{
-			input: []string{"helloworldhelloworldhe", "lloworld"},
+			input:    []string{"helloworldhelloworldhe", "lloworld"},
 			expected: "hello/world/hello/world/hello/world",
 		},
 		{
-			input: []string{"helloworldhelloworldhe", "llo", "wor", "ld"},
+			input:    []string{"helloworldhelloworldhe", "llo", "wor", "ld"},
 			expected: "hello/world/hello/world/hello/world",
 		},
 	}
@@ -49,6 +50,45 @@ func TestNew(t *testing.T) {
 		output := b.String()
 		if output != test.expected {
 			t.Error("Got " + output + " instead of " + test.expected)
+		}
+	}
+}
+
+func BenchmarkWriteWith10K(b *testing.B) {
+	b.ReportAllocs()
+
+	input := make([]byte, 10_000)
+	w := textwrapper.New(ioutil.Discard, "/", 3)
+	for i := 0; i < b.N; i++ {
+		_, err := w.Write(input)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkWriteWith100K(b *testing.B) {
+	b.ReportAllocs()
+
+	input := make([]byte, 100_000)
+	w := textwrapper.New(ioutil.Discard, "/", 3)
+	for i := 0; i < b.N; i++ {
+		_, err := w.Write(input)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkWriteWith1M(b *testing.B) {
+	b.ReportAllocs()
+
+	input := make([]byte, 1_000_000)
+	w := textwrapper.New(ioutil.Discard, "/", 3)
+	for i := 0; i < b.N; i++ {
+		_, err := w.Write(input)
+		if err != nil {
+			b.Error(err)
 		}
 	}
 }


### PR DESCRIPTION
Hello, I've recently started using `go-message` for an application that parses RFC822 and MIME messages, that have NO size limit. Since we expect there to be multi-gigabyte files in some cases, we need to work with near constant memory overhead.

After doing some pprof profiling I found a problem in `wrapper.go` on  line 28: `_, err = w.w.Write([]byte(w.Sep))`

Here is a quick benchmark of the problem:
```cmd
$ go test -bench=.
goos: windows
goarch: amd64
pkg: go-textwrapper
BenchmarkWriteWith10K-8            13562             88246 ns/op           26667 B/op       3333 allocs/op
BenchmarkWriteWith100K-8            1335            876308 ns/op          266747 B/op      33333 allocs/op
BenchmarkWriteWith1M-8               133           9061024 ns/op         2674257 B/op     333333 allocs/op
PASS
ok      go-textwrapper  5.608s
```

Since `Sep` can't be changed dynamically from outside the `textwrapper` package, it makes sense to convert it to bytes in the beginning when `New` is called.

After the suggested changes:
```cmd
$ go test -bench=.
goos: windows
goarch: amd64
pkg: go-textwrapper
BenchmarkWriteWith10K-8            54189             21874 ns/op               0 B/op          0 allocs/op
BenchmarkWriteWith100K-8            6015            211992 ns/op              17 B/op          0 allocs/op
BenchmarkWriteWith1M-8               561           2121501 ns/op            1796 B/op          0 allocs/op
PASS
ok      go-textwrapper  4.265s
```